### PR TITLE
Serve jQuery over HTTPS

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,2 +1,2 @@
-<script src="http://code.jquery.com/jquery-2.2.2.min.js" integrity="sha256-36cp2Co+/62rEAAYHLmRCPIych47CvdM+uTBJwSzWjI=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-2.2.2.min.js" integrity="sha256-36cp2Co+/62rEAAYHLmRCPIych47CvdM+uTBJwSzWjI=" crossorigin="anonymous"></script>
 <script type="text/javascript" src="{{ "js/application.min.js" | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
Chrome is throwing a Mixed Content error, blocking the page from loading HTTP content on an HTTPS connection.

See: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/fixing-mixed-content
